### PR TITLE
Bug fix - time report. Added Covaraince, time of transmission, time of validity.

### DIFF
--- a/msg/DVL.msg
+++ b/msg/DVL.msg
@@ -1,7 +1,7 @@
 #Header
 std_msgs/Header header
 
-#Time
+# Milliseconds since last velocity report (ms)
 float64 time
 
 #Measured velocity [m/s]
@@ -9,6 +9,9 @@ geometry_msgs/Vector3 velocity
 
 #Figure of Merit
 float64 fom
+
+#Covariance matrix, for the velocities. The figure of merit is calculated from this (entries in (m/s)^2)
+float64[] covariance
 
 #Altitude of the sensor
 float64 altitude
@@ -21,6 +24,12 @@ bool velocity_valid
 
 #Status message
 int64 status
+
+# Timestamp of the surface reflection, aka 'center of ping' (Unix timestamp in microseconds)
+int64 time_of_validity
+
+# Timestamp from immediately before sending of the report over TCP (Unix timestamp in microseconds)
+int64 time_of_transmission
 
 #Formatting of json
 string form


### PR DESCRIPTION
Corresponding pull request will be made on dvl-a50 driver. 

The time reported in the message was the "Milliseconds since last velocity report (ms)" not the actual time reported by the DVL when it recorded the measurement.

This is crucial for anyone using the NTP time sync to get accurate timestamps associated with the data.

Helpful for anyone using this with state estimation tasks with precise timing. 