### PR TITLE
DVL dead reckoning child frame id to follow ROS standards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/CommandResponse.msg"
   "msg/ConfigCommand.msg"
   "msg/ConfigStatus.msg"
+  "msg/TimeStatus.msg"
   DEPENDENCIES builtin_interfaces std_msgs geometry_msgs
  )
 

--- a/msg/CommandResponse.msg
+++ b/msg/CommandResponse.msg
@@ -5,3 +5,4 @@ string  error_message
 int32   result
 string  format
 string  type
+TimeStatus  time_status

--- a/msg/ConfigCommand.msg
+++ b/msg/ConfigCommand.msg
@@ -5,9 +5,15 @@
 # calibrate_gyro
 # get_config
 # set_config
+# trigger_ping      queue one ping (up to 15); requires acoustic_enabled=false
+# set_time_ntp      parameter_value: NTP server address or "auto"
+# get_time_ntp      (no parameters) -> publishes to dvl/time/status
+# set_time_manual   parameter_value: RFC3339 timestamp e.g. "2026-04-20T09:04:13Z"
+# get_time_status   (no parameters) -> publishes to dvl/time/status
+# force_sync_ntp    parameter_value: timeout in seconds (integer string)
 
 # DVL available parameters for set_config command
-# speed_of_sound: int 
+# speed_of_sound: int
 # acoustic_enabled: bool
 # dark_mode_enabled: bool
 # mounting_rotation_offset: double

--- a/msg/ConfigStatus.msg
+++ b/msg/ConfigStatus.msg
@@ -8,6 +8,7 @@ string  error_message
 int32   speed_of_sound
 bool    acoustic_enabled
 bool    dark_mode_enabled
+bool    periodic_cycling_enabled
 int32   mounting_rotation_offset
 string  range_mode
 

--- a/msg/DVLDR.msg
+++ b/msg/DVLDR.msg
@@ -23,3 +23,5 @@ int64 status
 
 #Formatting of json
 string format
+
+string child_frame_id

--- a/msg/TimeStatus.msg
+++ b/msg/TimeStatus.msg
@@ -1,0 +1,8 @@
+# NTP / time status sub-message, embedded in CommandResponse
+# Populated for: get_time_ntp, get_time_status, force_sync_ntp
+
+string ntp_address                   # get_time_ntp result
+string system_time                   # get_time_status / force_sync_ntp result
+bool ntp_synced
+string ntp_synced_to
+float64 ntp_seconds_since_last_sync  # -1.0 when not synchronized (null in JSON)


### PR DESCRIPTION
This pull request makes a small addition to the `msg/DVLDR.msg` message definition to include a new field for `child_frame_id`. This change allows the message to specify the child frame identifier, which can be useful for applications that require frame referencing.

- Added a new `string child_frame_id` field to the `DVLDR.msg` message definition to support referencing of child frames.… the coordinate frame convention

- Should be combined with PR on dvl-a50 https://github.com/paagutie/dvl-a50/pull/4